### PR TITLE
Install RStudio Professional Drivers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@
 rstudio_workbench_version: "2021.09.2-382.pro1"
 rstudio_workbench_install: []
 
+rstudio_workbench_install_pro_drivers: true
+
 rstudio_workbench_www_port: 8787
 rstudio_workbench_health_check_enabled: 0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,9 @@
 rstudio_workbench_version: "2021.09.2-382.pro1"
 rstudio_workbench_install: []
 
-rstudio_workbench_install_pro_drivers: true
+rstudio_workbench_pro_drivers_install: true
+rstudio_workbench_pro_drivers_version: "2021.10.0"
+rstudio_workbench_pro_drivers_dependencies: ["unixodbc", "unixodbc-dev"]
 
 rstudio_workbench_www_port: 8787
 rstudio_workbench_health_check_enabled: 0

--- a/tasks/install-drivers.yml
+++ b/tasks/install-drivers.yml
@@ -4,12 +4,10 @@
   get_url:
     url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_2021.10.0_amd64.deb"
     dest: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
-  when: rstudio_workbench_install_pro_drivers
 
 - name: install | pro-drivers
   apt:
     deb: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
-  when: rstudio_workbench_install_pro_drivers
 
 - name: configure | pro-drivers
   copy:
@@ -19,6 +17,5 @@
     owner: root
     group: root
     remote_src: true
-  when: rstudio_workbench_install_pro_drivers
 
 ...

--- a/tasks/install-drivers.yml
+++ b/tasks/install-drivers.yml
@@ -1,0 +1,21 @@
+---
+
+- name: install | pro-drivers (download)
+  get_url:
+    url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_2021.10.0_amd64.deb"
+    dest: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
+  when: rstudio_workbench_install_pro_drivers
+
+- name: install | pro-drivers
+  apt:
+    deb: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
+  when: rstudio_workbench_install_pro_drivers
+
+- name: configure | pro-drivers
+  copy:
+    src: /opt/rstudio-drivers/odbcinst.ini.sample
+    dest: /etc/odbcinst.ini
+    remote_src: true
+  when: rstudio_workbench_install_pro_drivers
+
+...

--- a/tasks/install-drivers.yml
+++ b/tasks/install-drivers.yml
@@ -15,6 +15,9 @@
   copy:
     src: /opt/rstudio-drivers/odbcinst.ini.sample
     dest: /etc/odbcinst.ini
+    mode: 0644
+    owner: root
+    group: root
     remote_src: true
   when: rstudio_workbench_install_pro_drivers
 

--- a/tasks/install-drivers.yml
+++ b/tasks/install-drivers.yml
@@ -1,15 +1,22 @@
 ---
 
-- name: install | pro-drivers (download)
-  get_url:
-    url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_2021.10.0_amd64.deb"
-    dest: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
-
-- name: install | pro-drivers
+- name: install pro-drivers | install dependencies
   apt:
-    deb: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_2021.10.0_amd64.deb"
+    name: "{{ rstudio_workbench_pro_drivers_dependencies }}"
+    state: "{{ apt_install_state | default('latest') }}"
+    update_cache: true
+    cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
 
-- name: configure | pro-drivers
+- name: install pro-drivers | download deb
+  get_url:
+    url: "{{ rstudio_workbench_pro_drivers_download_url }}"
+    dest: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_{{ rstudio_workbench_pro_drivers_version }}_{{ rstudio_workbench_machine_map[ansible_machine] }}.deb"
+
+- name: install pro-drivers | install deb
+  apt:
+    deb: "{{ rstudio_workbench_downloads_path }}/rstudio-drivers_{{ rstudio_workbench_pro_drivers_version }}_{{ rstudio_workbench_machine_map[ansible_machine] }}.deb"
+
+- name: configure pro-drivers | create odbcinst.ini
   copy:
     src: /opt/rstudio-drivers/odbcinst.ini.sample
     dest: /etc/odbcinst.ini

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     - r-version-install
 
 - include: install-drivers.yml
-  when: rstudio_workbench_install_pro_drivers
+  when: rstudio_workbench_pro_drivers_install
 
 - name: start and enable service
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     - r-version-install
 
 - include: install-drivers.yml
+  when: rstudio_workbench_install_pro_drivers
 
 - name: start and enable service
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,8 @@
   tags:
     - r-version-install
 
+- include: install-drivers.yml
+
 - name: start and enable service
   service:
     name: rstudio-server

--- a/vars/_focal.yml
+++ b/vars/_focal.yml
@@ -1,4 +1,7 @@
 # vars file
 ---
 rstudio_workbench_download_url: "https://download2.rstudio.org/server/bionic/{{ rstudio_workbench_machine_map[ansible_machine] }}/rstudio-workbench-{{ rstudio_workbench_version }}-{{ rstudio_workbench_machine_map[ansible_machine] }}.deb"
+
+rstudio_workbench_pro_drivers_download_url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_{{ rstudio_workbench_pro_drivers_version }}_{{ rstudio_workbench_machine_map[ansible_machine] }}.deb"
+
 r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release|replace('.','') }}/pkgs"


### PR DESCRIPTION
Description: https://docs.rstudio.com/pro-drivers/installation/#installing-rstudio-professional-drivers

Note: I used `when` instead of `tags` for this case, because I feel like it's easier to disable or enable it with variable, for ones that will be using this code. Plus, this [article](https://gswallow.medium.com/ansible-tags-are-a-code-smell-bf80bd88cb79) that I agree with. 

ToDo: 
- [x] add step with "sudo apt-get install unixodbc unixodbc-dev gdebi" 