### PR TITLE
Upgrade version to 2022.02.2+485

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults file
 ---
 
-rstudio_workbench_version: "2021.09.2-382.pro1"
+rstudio_workbench_version: "2022.02.2-485.pro2"
 rstudio_workbench_install: []
 
 rstudio_workbench_www_port: 8787

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,8 @@
 # meta file
 ---
 galaxy_info:
-  namespace: appsilon
   role_name: rstudio_workbench
-  author: DamianBudelewski
+  author: damianbudelewski
   company: Appsilon
   description: Set up (the latest version of) RStudio Workbench in Debian-like systems
   license: MIT

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
+  - name: instance-rsw
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:


### PR DESCRIPTION
## Changes description

This PR:
- upgrades default RSW version to 2022.02.2+485
- fixes `ansible-lint`

For more information regarding the changes, see official [release notes](https://www.rstudio.com/products/rstudio/release-notes/) for RStudio Workbench.