### PR TITLE
fix(lint): added missing spaces for filters

### DIFF
--- a/vars/_focal.yml
+++ b/vars/_focal.yml
@@ -3,4 +3,4 @@
 
 rstudio_workbench_download_url: "https://download2.rstudio.org/server/bionic/{{ rstudio_workbench_machine_map[ansible_machine] }}/rstudio-workbench-{{ rstudio_workbench_version }}-{{ rstudio_workbench_machine_map[ansible_machine] }}.deb"
 
-r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release|replace('.','') }}/pkgs"
+r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release | replace('.','') }}/pkgs"


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

Small fix of linting errors, which occur during running CI workflow.

Ansible-lint added a rule for checking if there are spaces before and after filters. This change was introduced in version [6.3.0](https://github.com/ansible/ansible-lint/releases/tag/v6.3.0).

CI workflow always uses the latest version, so the errors appeared after the mentioned version of ansible-lint was released.

I just added missing spaces and linted locally the code with ansible-lint in the latest version (6.4.0). Should be ok now.
