### PR TITLE
chore: bump version to 2022.12.0-353.pro20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Set up (the latest version of) [RStudio Workbench](https://www.rstudio.com/produ
 
 ## Role Variables
 
-* `rstudio_workbench_version` [default: `2021.09.0-351.pro6`]: Version to install.
+* `rstudio_workbench_version` [default: `2022.12.0-353.pro20`]: Version to install.
 * `rstudio_workbench_install` [default: `[]`]: Additional packages to install (e.g. `r-base`).
 * `rstudio_workbench_www_port` [default: `8787`]: The port you want RStudio Workbench to listen on>
 * `rstudio_workbench_health_check_enabled` [default: 0]: Decision if you want to activate `http://<server-address-and-port>/health-check` endpoint.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults file
 ---
 
-rstudio_workbench_version: "2022.02.2-485.pro2"
+rstudio_workbench_version: "2022.12.0-353.pro20"
 rstudio_workbench_install: []
 
 rstudio_workbench_www_port: 8787


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

- Bump default Workbench version to `2022.12.0-353.pro20`
